### PR TITLE
Adjust search layout and unify map markers

### DIFF
--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -18,7 +18,8 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import MapView, { Marker, Region } from 'react-native-maps';
+import MapView, { Region } from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 
 
 export default function AddVisitScreen() {
@@ -220,7 +221,7 @@ export default function AddVisitScreen() {
           rotateEnabled={false}
           toolbarEnabled={false}
         >
-          <Marker coordinate={marker} />
+          <SmallMarker coordinate={marker} />
         </MapView>
       )}
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,7 +5,8 @@ import { FontAwesome } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
 import { Dimensions, FlatList, Image, Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const ITEM_WIDTH = SCREEN_WIDTH * 0.85;
@@ -287,7 +288,7 @@ function VisitMap({ visits }: { visits: any[] }) {
         liteMode={true}
       >
         {visits.map((v, i) => (
-          <Marker
+          <SmallMarker
             key={i}
             coordinate={{ latitude: v.latitude, longitude: v.longitude }}
             title={v.beach}

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,7 +1,8 @@
 import { supabase } from '@/lib/supabase';
 import { useEffect, useState } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 
 
 const BEACH_COORDINATES: Record<string, { latitude: number; longitude: number }> = {
@@ -67,7 +68,7 @@ export default function MapScreen() {
             }
 
             return (
-              <Marker
+              <SmallMarker
                 key={visit.id}
                 coordinate={coords}
                 title={`${visit.user.name} - ${visit.beach}`}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,7 +1,8 @@
 import { supabase } from '@/lib/supabase';
 import { useEffect, useState } from 'react';
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ProfileScreen() {
@@ -156,7 +157,7 @@ export default function ProfileScreen() {
               (v, i) =>
                 v.latitude &&
                 v.longitude && (
-                  <Marker
+                  <SmallMarker
                     key={i}
                     coordinate={{ latitude: v.latitude, longitude: v.longitude }}
                     title={v.beach}

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -3,12 +3,14 @@ import { useEffect, useState } from 'react';
 import {
   FlatList,
   Image,
+  Text,
   SafeAreaView,
   StyleSheet,
   TextInput,
   View,
 } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 
 export default function SearchTab() {
   const [visits, setVisits] = useState<any[]>([]);
@@ -39,6 +41,9 @@ export default function SearchTab() {
     <View style={styles.item}>
       <View style={styles.imageWrapper}>
         <Image source={{ uri: item.photo_url }} style={styles.image} />
+        <View style={styles.usernameOverlay}>
+          <Text style={styles.username}>{item.username}</Text>
+        </View>
         {item.latitude && item.longitude && (
           <MapView
             style={styles.mapOverlay}
@@ -55,7 +60,7 @@ export default function SearchTab() {
             pointerEvents="none"
             liteMode={true}
           >
-            <Marker
+            <SmallMarker
               coordinate={{ latitude: item.latitude, longitude: item.longitude }}
             />
           </MapView>
@@ -107,8 +112,21 @@ const styles = StyleSheet.create({
   },
   image: {
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: 0.75,
     borderRadius: 8,
+  },
+  usernameOverlay: {
+    position: 'absolute',
+    top: 8,
+    left: 8,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  username: {
+    color: '#fff',
+    fontSize: 12,
   },
   mapOverlay: {
     position: 'absolute',

--- a/app/user/[userId].tsx
+++ b/app/user/[userId].tsx
@@ -3,7 +3,8 @@ import { useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Pressable } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
+import SmallMarker from '@/components/SmallMarker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function UserProfileScreen() {
@@ -200,7 +201,7 @@ export default function UserProfileScreen() {
               (v, i) =>
                 v.latitude &&
                 v.longitude && (
-                  <Marker
+                  <SmallMarker
                     key={i}
                     coordinate={{ latitude: v.latitude, longitude: v.longitude }}
                     title={v.beach}

--- a/components/SmallMarker.tsx
+++ b/components/SmallMarker.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Marker, MarkerProps } from 'react-native-maps';
+
+/**
+ * Small round marker used across the app. The `Marker` component renders a
+ * small circle instead of the default pin.
+ */
+export default function SmallMarker(props: MarkerProps) {
+  return (
+    <Marker {...props} tracksViewChanges={false} anchor={{ x: 0.5, y: 0.5 }}>
+      <View
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: 5,
+          backgroundColor: '#0a7ea4',
+          borderWidth: 1,
+          borderColor: '#fff',
+        }}
+      />
+    </Marker>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `SmallMarker` component
- overlay username on search images
- make search images taller
- use `SmallMarker` across map screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416d7668d883299edf060cc776663b