### PR TITLE
Add visit modal with double-tap like

### DIFF
--- a/app/(modals)/visit/[visitId].tsx
+++ b/app/(modals)/visit/[visitId].tsx
@@ -1,0 +1,97 @@
+import { supabase } from '@/lib/supabase';
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { View, Image, StyleSheet, Text } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { TapGestureHandler } from 'react-native-gesture-handler';
+
+export default function VisitModal() {
+  const { visitId } = useLocalSearchParams<{ visitId: string }>();
+  const [visit, setVisit] = useState<any | null>(null);
+  const [likes, setLikes] = useState(0);
+
+  useEffect(() => {
+    fetchVisit();
+  }, [visitId]);
+
+  const fetchVisit = async () => {
+    if (!visitId) return;
+    const { data, error } = await supabase
+      .from('visits')
+      .select('*, profiles(name)')
+      .eq('id', visitId)
+      .single();
+
+    if (!error && data) {
+      const enriched = { ...data, username: data.profiles?.name ?? 'Alguien' };
+      setVisit(enriched);
+      const dayId = `${enriched.user_id}_${new Date(enriched.created_at)
+        .toISOString()
+        .slice(0, 10)}`;
+      const { count } = await supabase
+        .from('visit_day_likes')
+        .select('*', { count: 'exact', head: true })
+        .eq('visit_day_id', dayId);
+      setLikes(count ?? 0);
+    }
+  };
+
+  const likeVisitDay = async () => {
+    if (!visit) return;
+    const visitDayId = `${visit.user_id}_${new Date(visit.created_at)
+      .toISOString()
+      .slice(0, 10)}`;
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    const user = session?.user;
+    if (!user) return;
+
+    await supabase
+      .from('visit_day_likes')
+      .insert({ user_id: user.id, visit_day_id: visitDayId });
+
+    fetchVisit();
+  };
+
+  if (!visit) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Stack.Screen options={{ title: 'Visita', presentation: 'modal' }} />
+        <Text>Cargando...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: visit.username, presentation: 'modal' }} />
+      <TapGestureHandler numberOfTaps={2} onActivated={likeVisitDay}>
+        <Image source={{ uri: visit.photo_url }} style={styles.image} />
+      </TapGestureHandler>
+      <View style={styles.likesOverlay}>
+        <FontAwesome name="heart" size={24} color="white" />
+        <Text style={styles.likesText}>{likes}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  image: { flex: 1, resizeMode: 'contain' },
+  likesOverlay: {
+    position: 'absolute',
+    bottom: 40,
+    left: 20,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  likesText: { color: '#fff', fontSize: 16 },
+});

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,10 +1,12 @@
 import { supabase } from '@/lib/supabase';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'expo-router';
 import { FontAwesome } from '@expo/vector-icons';
 import {
   FlatList,
   Image,
   Text,
+  Pressable,
   SafeAreaView,
   StyleSheet,
   TextInput,
@@ -17,6 +19,7 @@ export default function SearchTab() {
   const [visits, setVisits] = useState<any[]>([]);
   const [dayLikes, setDayLikes] = useState<Record<string, number>>({});
   const [query, setQuery] = useState('');
+  const router = useRouter();
 
   useEffect(() => {
     fetchRandomVisits();
@@ -58,7 +61,7 @@ export default function SearchTab() {
   };
 
   const renderItem = ({ item }: { item: any }) => (
-    <View style={styles.item}>
+    <Pressable style={styles.item} onPress={() => router.push(`/visit/${item.id}`)}>
       <View style={styles.imageWrapper}>
         <Image source={{ uri: item.photo_url }} style={styles.image} />
         <View style={styles.usernameOverlay}>
@@ -95,7 +98,7 @@ export default function SearchTab() {
           </MapView>
         )}
       </View>
-    </View>
+    </Pressable>
   );
 
   const countryCodeToEmoji = (cc: string) =>


### PR DESCRIPTION
## Summary
- create modal route to view a visit
- enable liking the visit's day with a double‑tap
- link search cards to the new modal

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b5f8663c83298c55034187cfe50e