### PR TITLE
Store location data and display on feed

### DIFF
--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -33,7 +33,7 @@ export default function AddVisitScreen() {
   const navigation = useNavigation();
   const [photoTaken, setPhotoTaken] = useState(false);
   const [city, setCity] = useState<string | null>(null);
-  const [countryName, setCountryName] = useState<string | null>(null);
+  const [countryLarge, setCountryLarge] = useState<string | null>(null);
   const [isoCountry, setIsoCountry] = useState<string | null>(null);
   const cameraRef = useRef<CameraView>(null);
 
@@ -67,7 +67,7 @@ export default function AddVisitScreen() {
       const locInfo = await getCountryFromCoords(latitude, longitude);
       if (locInfo) {
         setCity(locInfo.city);
-        setCountryName(locInfo.country);
+        setCountryLarge(locInfo.country);
         setIsoCountry(locInfo.isoCountryCode);
       }
     })();
@@ -222,6 +222,8 @@ export default function AddVisitScreen() {
         latitude: marker.latitude,
         longitude: marker.longitude,
         country: isoCountry,
+        city,
+        countryLarge,
       },
     ]);
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -208,7 +208,11 @@ export default function HomeTab() {
                     <View style={[styles.visitPreview, { width: ITEM_WIDTH, marginRight: SPACING }]}>
                       <Image source={{ uri: v.photo_url }} style={styles.visitImage} />
                       <View style={styles.infoOverlay}>
-                        <Text style={styles.visitBeach}>{v.beach}</Text>
+                        <Text style={styles.visitBeach}>
+                          {v.city && v.countryLarge
+                            ? `${v.city}, ${v.countryLarge}`
+                            : v.beach}
+                        </Text>
                         {v.comment ? <Text style={styles.visitComment}>“{v.comment}”</Text> : null}
                       </View>
                     </View>


### PR DESCRIPTION
## Summary
- store location info when creating a visit
- display city and long country name instead of beach name on the home feed

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842da04c1dc8329b800c336ba159fde